### PR TITLE
Yuzu profile info

### DIFF
--- a/src/views/play/yuzu.vue
+++ b/src/views/play/yuzu.vue
@@ -68,9 +68,12 @@
           </b-tooltip>
         </li>
         <li>
-          [Optional] While you are still in the <code>System</code> settings, head over to the <code>Profiles</code> tab
+          While you are still in the <code>System</code> settings, head over to the <code>Profiles</code> tab
           to create a new user with a name you like. The name of the profile will be shown to other players.
-          Once the profile is created, simply click on it once to select it as the current user. Otherwise you're displayed with the name <code>yuzu</code>.
+          Once the profile is created, simply click on it once to select it as the current user. Otherwise you're displayed with the name <code>yuzu</code>. <b-icon icon="info-circle-fill" id="common-uuid-errors"/>
+          <b-tooltip target="common-uuid-errors" triggers="hover">
+              this is solve some of the most common errors relating with uuid's on yuzu
+          </b-tooltip>
         </li>
       </ul>
     </p>


### PR DESCRIPTION
Changes yuzu profile info to no longer be optional to try and solve some of the most common errors

![image](https://user-images.githubusercontent.com/100526773/199479852-16a87a6c-c351-4c6b-a022-1f06e7facb99.png)

![image](https://user-images.githubusercontent.com/100526773/199479888-7aafe5a4-5482-411e-8029-ce5d2d8eb55e.png)
