### PR TITLE
servers(schwegelbin): update version

### DIFF
--- a/src/store/servers.ts
+++ b/src/store/servers.ts
@@ -266,7 +266,7 @@ export const servers: IServer[] = [
     name     : 'SchweGELBin',
     server   : { host: 'schwegelbin.smoo.it', ip: '78.47.17.130', port: 1027 },
     location : { flag: 'de', name: 'Germany' },
-    version  : linkTree('main', 'SchweGELBin/main', 'SchweGELBin/SMOOS-CS'),
+    version  : linkTree('main', 'smoos-cs', 'SchweGELBin/smoos'),
     settings : {
       Server: { MaxPlayers: 8 },
     },


### PR DESCRIPTION
Hey, I've deprecated my old fork of the official smoo server and updated the version here to match the new repo.

I've built a wrapper around the official Server with the help of nix.
The actual Server is in a subdir: https://github.com/SchweGELBin/smoos/tree/main/smoos-cs