### PR TITLE
servers: add `SchweGELBin 2`

### DIFF
--- a/src/store/servers.ts
+++ b/src/store/servers.ts
@@ -271,6 +271,15 @@ export const servers: IServer[] = [
       Server: { MaxPlayers: 8 },
     },
   },
+  {
+    name     : 'SchweGELBin 2',
+    server   : { host: 'schwegelbin.smoo.it', ip: '138.199.210.86', port: 1028 },
+    location : { flag: 'de', name: 'Germany' },
+    version  : linkTree('main', 'SchweGELBin/smoos-rs', 'SchweGELBin/smoos'),
+    settings : {
+      Server: { MaxPlayers: 8 },
+    },
+  },
 ].map((s: IServer) => {
   s.server.state = null
   return s


### PR DESCRIPTION
Hey,

I'm hosting the official C# Server at port 1027 (SchweGELBin) and the Rust Server at port 1028 (SchweGELBin 2) now.

The Rust Server doesn't allow using the same port for the JsonApi, so it's available at 1128.
Please let me know wether this works or not. If it does, I can give you the public key via E-Mail.

Have a great day!