### PR TITLE
Add 2Fast servers (Main + Capture Sync)

### DIFF
--- a/src/store/servers.ts
+++ b/src/store/servers.ts
@@ -54,10 +54,10 @@ export const servers: IServer[] = [
     location : { flag: 'de', name: 'Germany' },
     version  : linkRelease('1.0.5-rcl.8', 'rcl/1.0.5', 'Istador/SmoOnlineServer'),
     settings : {
-      Server         : { MaxPlayers: 12 },
-      Scenario       : { MergeEnabled: true },
-      Shines         : { Emabled: true },
-      PersistShines  : { Enabled: true },
+      Server        : { MaxPlayers: 12 },
+      Scenario      : { MergeEnabled: true },
+      Shines        : { Enabled: true },
+      PersistShines : { Enabled: true },
     },
   },
   {
@@ -146,30 +146,30 @@ export const servers: IServer[] = [
       PersistShines : { Enabled: true },
     },
   },
-{
-  name     : '2Fast (Main)',
-  server   : { host: '2fast.smoo.it', ip: '74.208.191.249', port: 1027 },
-  location : { flag: 'us', name: 'US-Central' },
-  version  : linkTree('master', 'Sanae6/master', 'Sanae6/SmoOnlineServer'),
-  settings : {
-    Server        : { MaxPlayers: 10 },
-    Scenario      : { MergeEnabled: true },
-    Shines        : { Enabled: true },
-    PersistShines : { Enabled: true },
+  {
+    name     : '2Fast (Main)',
+    server   : { host: '2fast.smoo.it', ip: '74.208.191.249', port: 1027 },
+    location : { flag: 'us', name: 'US-Central' },
+    version  : linkTree('master', 'Sanae6/master', 'Sanae6/SmoOnlineServer'),
+    settings : {
+      Server        : { MaxPlayers: 10 },
+      Scenario      : { MergeEnabled: true },
+      Shines        : { Enabled: true },
+      PersistShines : { Enabled: true },
+    },
   },
-},
-{
-  name     : '2Fast (Capture Sync)',
-  server   : { host: '2fast.smoo.it', ip: '74.208.191.249', port: 1028 },
-  location : { flag: 'us', name: 'US-Central' },
-  version  : linkTree('master', 'Sanae6/master', 'Sanae6/SmoOnlineServer'),
-  settings : {
-    Server        : { MaxPlayers: 8 },
-    Scenario      : { MergeEnabled: true },
-    Shines        : { Enabled: true },
-    PersistShines : { Enabled: true },
+  {
+    name     : '2Fast (Capture Sync)',
+    server   : { host: '2fast.smoo.it', ip: '74.208.191.249', port: 1028 },
+    location : { flag: 'us', name: 'US-Central' },
+    version  : linkTree('master', 'Sanae6/master', 'Sanae6/SmoOnlineServer'),
+    settings : {
+      Server        : { MaxPlayers: 8 },
+      Scenario      : { MergeEnabled: true },
+      Shines        : { Enabled: true },
+      PersistShines : { Enabled: true },
+    },
   },
-}, 
 ].map((s: IServer) => {
   s.server.state = null
   return s

--- a/src/store/servers.ts
+++ b/src/store/servers.ts
@@ -146,6 +146,30 @@ export const servers: IServer[] = [
       PersistShines : { Enabled: true },
     },
   },
+{
+  name     : '2Fast (Main)',
+  server   : { host: '2fast.smoo.it', ip: '74.208.191.249', port: 1027 },
+  location : { flag: 'us', name: 'US-Central' },
+  version  : linkTree('master', 'Sanae6/master', 'Sanae6/SmoOnlineServer'),
+  settings : {
+    Server        : { MaxPlayers: 10 },
+    Scenario      : { MergeEnabled: true },
+    Shines        : { Enabled: true },
+    PersistShines : { Enabled: true },
+  },
+},
+{
+  name     : '2Fast (Capture Sync)',
+  server   : { host: '2fast.smoo.it', ip: '74.208.191.249', port: 1028 },
+  location : { flag: 'us', name: 'US-Central' },
+  version  : linkTree('master', 'Sanae6/master', 'Sanae6/SmoOnlineServer'),
+  settings : {
+    Server        : { MaxPlayers: 8 },
+    Scenario      : { MergeEnabled: true },
+    Shines        : { Enabled: true },
+    PersistShines : { Enabled: true },
+  },
+}, 
 ].map((s: IServer) => {
   s.server.state = null
   return s


### PR DESCRIPTION
Adds two new public servers:

- 2Fast (Main) — US-Central — 10 players — port 1027
- 2Fast (Capture Sync) — US-Central — 8 players — port 1028